### PR TITLE
refactor: Use search display instead on modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -497,7 +497,6 @@ a[data-tooltip] {
 	}
 }
 
-// top tooltip
 a[data-tooltip][data-position="top"]:before {
 	bottom: 100%;
 	left: -130%;
@@ -511,51 +510,6 @@ a[data-tooltip][data-position="top"]:after {
 	left: calc(50% - 6px);
 	margin-bottom: 4px;
 }
-// left tooltip
-a[data-tooltip][data-position="left"]:before {
-	top: -12%;
-	right: 100%;
-	margin-right: 10px;
-}
-
-a[data-tooltip][data-position="left"]:after {
-	border-left-color: #000;
-	border-right: none;
-	top: calc(50% - 3px);
-	right: 100%;
-	margin-top: -6px;
-	margin-right: 4px;
-}
-// right tooltip
-a[data-tooltip][data-position="right"]:before {
-	top: -5%;
-	left: 100%;
-	margin-left: 10px;
-}
-
-a[data-tooltip][data-position="right"]:after {
-	border-right-color: #000;
-	border-left: none;
-	top: calc(50% - 6px);
-	left: calc(100% + 4px);
-}
-
-// bottom tooltip
-a[data-tooltip][data-position="bottom"]:before {
-	top: 100%;
-	left: -130%;
-	margin-top: 10px;
-}
-
-a[data-tooltip][data-position="bottom"]:after {
-	border-bottom-color: #000;
-	border-top: none;
-	top: 100%;
-	left: 5px;
-	margin-top: 4px;
-}
-
-
 
 
 @media (max-width: 768px) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css';
 import { LandingSearch } from './pages/LandingSearch';
 import { WeatherDisplay } from './pages/WeatherDisplayGeo';
 import { NotFound } from './pages/NotFound';
+import { SearchDisplay } from './pages/SearchDisplay';
 
 function App() {
 
@@ -10,6 +11,7 @@ function App() {
     <div className="app">
       <Routes>
         <Route path="/" element={<LandingSearch />} />
+        <Route path="/search" element={<SearchDisplay />} />
         <Route path="/weather" element={<WeatherDisplay />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/pages/SearchDisplay.jsx
+++ b/src/pages/SearchDisplay.jsx
@@ -1,0 +1,10 @@
+import SearchBar from "../components/SearchBarGeo";
+
+export function SearchDisplay() {
+
+  return (
+    <main className="search-page">
+      <SearchBar />
+    </main>
+  );
+}

--- a/src/pages/WeatherDisplayGeo.jsx
+++ b/src/pages/WeatherDisplayGeo.jsx
@@ -2,13 +2,12 @@ import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useWeather } from "../hooks/useWeatherGeo";
 import { WeatherProvider } from "../context/WeatherContext";
+import { useNavigate } from "react-router-dom";
 import LocationSection from "../components/LocationSectionGeo";
 import BrollyWeather from "../components/BrollyWeather";
 import CurrentWeather from "../components/CurrentWeather";
 import ExpectedWeather from "../components/ExpectedWeather";
 import ErrorBoundary from "../components/ErrorBoundary";
-import SearchBar from "../components/SearchBarGeo";
-import Modal from "../components/Modal";
 
 import "./LandingSearch.css";
 import './WeatherDisplay.css';
@@ -16,7 +15,7 @@ import logo from '../assets/logo/brolly.svg';
 import search from '../assets/icons/search.svg';
 
 export function WeatherDisplay() {
-  const [modal, setModal] = useState(false);
+  const navigate = useNavigate();
   const location = useLocation(); // Use useLocation to access the state
   const { state } = location; // Extract the state object
   const queryLat = state?.lat; // Access latitude from state
@@ -71,7 +70,7 @@ export function WeatherDisplay() {
           <header>
             <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
             <img src={logo} alt="brolly" />
-            <a className="search" onClick={() => setModal(true)}>
+            <a className="search" onClick={() => navigate("/search")}>
               <img src={search} alt="Search" />
             </a>
           </header>
@@ -86,11 +85,6 @@ export function WeatherDisplay() {
             </aside>
           </div>
         </main>
-        {modal && (
-          <Modal modal={setModal} style="modal-page search-page">
-            <SearchBar />
-          </Modal>
-        )}
       </WeatherProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Refactor: Dedicated Search Page

This pull request moves the search bar from a pop-up modal to its own dedicated **Search Page**.

**Key changes:**

* **New Search Page:** Created a `SearchDisplay` page with the search bar. When you search from the weather page, you'll now go to this page.
* **Routing:** Added a route for the new Search Page.

**Why this change?**

* **Easier to Use:** A full page for search is cleaner and more straightforward.
* **Simpler Code:** Removes the complexity of managing the search bar as a pop-up modal.
* **More Organized:** Makes the codebase easier to manage and grow.