### PR TITLE
feat: useUnitContext and localStorage for unitToggle

### DIFF
--- a/src/components/UnitToggle.css
+++ b/src/components/UnitToggle.css
@@ -1,0 +1,19 @@
+.toggle-button {
+  background-color: var(--background-light);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--font-size-sm);
+  border: none;
+}
+
+.toggle-button span {
+  color: var(--text-light);
+}
+
+.toggle-button span.active {
+  color: var(--text-dark);
+}

--- a/src/components/UnitToggle.jsx
+++ b/src/components/UnitToggle.jsx
@@ -1,0 +1,14 @@
+import { useUnitContext } from "../context/UnitContext";
+import "./UnitToggle.css";
+
+export function UnitToggle() {
+  const { unit, toggleUnit } = useUnitContext();
+
+  return (
+    <button className="toggle-button" onClick={toggleUnit}>
+      <span className={unit === "metric" ? "active" : ""}>°C</span>
+      |
+      <span className={unit === "imperial" ? "active" : ""}>°F</span>
+    </button>
+  );
+}

--- a/src/components/WeatherCurrent.jsx
+++ b/src/components/WeatherCurrent.jsx
@@ -1,10 +1,12 @@
 import { useWeatherContext } from "../context/WeatherContext";
+import { useUnitContext } from "../context/UnitContext";
 
 import WeatherItem from "./WeatherItem";
 import { Skeleton } from "./Loading";
 
 function WeatherCurrent() {
-  const { current, loading, error, unit } = useWeatherContext(); // Access data from WeatherContext
+  const { current, loading, error } = useWeatherContext(); // Access data from WeatherContext
+  const { unit } = useUnitContext(); // Access unit from UnitContext
   /*
   // Show loading skeleton while fetching data
   if (loading) {

--- a/src/components/WeatherExpected.jsx
+++ b/src/components/WeatherExpected.jsx
@@ -1,10 +1,12 @@
 import { useWeatherContext } from "../context/WeatherContext";
+import { useUnitContext } from "../context/UnitContext";
 
 import WeatherItem from "./WeatherItem";
 import { Skeleton } from "./Loading";
 
 function WeatherExpected() {
-  const { forecast, loading, error, unit } = useWeatherContext(); // Access data from WeatherContext
+  const { forecast, loading, error } = useWeatherContext(); // Access data from WeatherContext
+    const { unit } = useUnitContext(); // Access unit from UnitContext
   /*
   // Show loading skeleton while fetching data
   if (loading) {

--- a/src/components/WeatherItem.jsx
+++ b/src/components/WeatherItem.jsx
@@ -1,6 +1,6 @@
 import getWeatherIcon from "../utils/getWeatherIcon";
 
-function WeatherItem({time, condition, temperature, icon, unit}) {
+function WeatherItem({ time, condition, temperature, icon, unit }) {
   const iconsrc = getWeatherIcon(icon);
 
   let displayTemperature = temperature;

--- a/src/context/UnitContext.jsx
+++ b/src/context/UnitContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const UnitContext = createContext();
+
+export function UnitProvider({ children }) {
+  const [unit, setUnit] = useState(() => {
+    return localStorage.getItem("unit") || "metric";
+  });
+
+  const toggleUnit = () => {
+    setUnit((prevUnit) => {
+      const newUnit = prevUnit === "metric" ? "imperial" : "metric";
+      localStorage.setItem("unit", newUnit);
+      return newUnit;
+    });
+  };
+
+  useEffect(() => {
+    localStorage.setItem("unit", unit);
+  }, [unit]);
+
+  return (
+    <UnitContext.Provider value={{ unit, toggleUnit }}>
+      {children}
+    </UnitContext.Provider>
+  );
+}
+
+export function useUnitContext() {
+  return useContext(UnitContext);
+}

--- a/src/pages/Weather.css
+++ b/src/pages/Weather.css
@@ -137,30 +137,6 @@
 }
 
 
-
-.toggle-button {
-  background-color: var(--background-light);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--border-radius-md);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: var(--font-size-sm);
-  border: none;
-}
-
-.toggle-button span {
-  color: var(--text-light);
-}
-
-.toggle-button span.active {
-  color: var(--text-dark);
-}
-
-
-
-
 @media (max-width: 768px) {
 
   .weather-page {

--- a/src/pages/Weather.jsx
+++ b/src/pages/Weather.jsx
@@ -3,11 +3,13 @@ import { useLocation } from "react-router-dom";
 
 import { useWeather } from "../hooks/useWeather";
 import { WeatherProvider } from "../context/WeatherContext";
+import { UnitProvider } from "../context/UnitContext";
 
 import { LocationSearchLink } from "../components/LocationSearch";
 import WeatherBrolly from "../components/WeatherBrolly";
 import WeatherCurrent from "../components/WeatherCurrent";
 import WeatherExpected from "../components/WeatherExpected";
+import { UnitToggle } from "../components/UnitToggle";
 import { Loading } from "../components/Loading";
 
 import logo from "../assets/logo/brolly.svg";
@@ -25,12 +27,6 @@ export function Weather() {
 
   const { current, forecast, loading, error } = useWeather(queryLat, queryLon);
 
-  // Metric or Imperial
-  const [unit, setUnit] = useState("metric"); 
-  const toggleUnit = () => {
-    setUnit((prevUnit) => (prevUnit === "metric" ? "imperial" : "metric"));
-  };
-
   if (loading) {
     return <Loading section="weather-page" />;
   }
@@ -44,30 +40,30 @@ export function Weather() {
   }
   
   return (
-    <WeatherProvider value={{ current, forecast, loading, error, name: queryName, unit }}>
-      <main className="weather-page">
-        <header>
-          <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
-          <img src={logo} alt="Brolly logo" />
-          <LocationSearchLink type="icon" />
-        </header>
+    <UnitProvider>
+      <WeatherProvider value={{ current, forecast, loading, error, name: queryName }}>
+        <main className="weather-page">
+          <header>
+            <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
+            <img src={logo} alt="Brolly logo" />
+            <LocationSearchLink type="icon" />
+          </header>
 
-        <div className="content">
-          <article className="brolly">
-            <WeatherBrolly />
-          </article>
+          <div className="content">
+            <article className="brolly">
+              <WeatherBrolly />
+            </article>
 
-          <aside className="weather">
-            <WeatherCurrent />
-            <WeatherExpected />
-          </aside>
-        </div>
-        <footer>
-          <button className="toggle-button" onClick={toggleUnit}>
-            <span className={unit === "metric" ? "active" : ""}>°C</span> / <span className={unit === "imperial" ? "active" : ""}>°F</span>
-          </button>
-        </footer>
-      </main>
-    </WeatherProvider>
+            <aside className="weather">
+              <WeatherCurrent />
+              <WeatherExpected />
+            </aside>
+          </div>
+          <footer>
+            <UnitToggle />
+          </footer>
+        </main>
+      </WeatherProvider>
+    </UnitProvider>
   );
 }


### PR DESCRIPTION
# **Unit Toggle Enhancements**

- **`UnitContext` context**:
  - Provides `unit` (`metric` or `imperial`) and `toggleUnit` function.
  - Saves unit preference to `localStorage` on change.
  - Wraps the app inside a `UnitProvider` to make unit state available globally.