### PR TITLE
Add render.yaml for full-stack deployment to Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: brolly
+    env: node
+    rootDir: server
+    buildCommand: |
+      npm install
+      cd ../client && npm install && npm run build
+    startCommand: node index.js
+    envVars:
+      - key: OPENWEATHER_API_KEY
+        sync: false
+      - key: NODE_ENV
+        value: production


### PR DESCRIPTION
This PR introduces a `render.yaml` file to enable automated deployment of the full-stack React + Express app to [Render](https://render.com/).

The setup includes:
- Using `server/` as the backend root directory (Express)
- Installing dependencies and building the React frontend from `client/`
- Serving the static React build from the Express backend
- Setting up environment variables, including `OPENWEATHER_API_KEY`

With this config, Render will build and deploy the entire app from a single service endpoint.