### PR TITLE
fix: define __dirname workaround for ES module compatibility

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     rootDir: server
     buildCommand: |
       npm install
-      cd ../client && npm install && npm run build
+      cd ../client && npm install --include=dev && npm run build
     startCommand: node index.js
     envVars:
       - key: OPENWEATHER_API_KEY

--- a/server/index.js
+++ b/server/index.js
@@ -3,8 +3,13 @@ import axios from 'axios';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 dotenv.config();
+
+// Fix for __dirname in ES module scope
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -42,10 +47,8 @@ app.get('/weather', async (req, res) => {
 
 // Serve static files in production
 if (process.env.NODE_ENV === 'production') {
-  // Serve the static files from React's build folder
   app.use(express.static(path.join(__dirname, '../client/dist')));
 
-  // Catch-all handler to serve index.html for all non-API routes
   app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '../client/dist/index.html'));
   });


### PR DESCRIPTION
- Added missed files from previous commit.

Fixes a server-side runtime error caused by the use of __dirname in an ES module. Since "type": "module" is set in package.json, __dirname is not defined by default in the module scope.

This PR adds a workaround using import.meta.url and fileURLToPath to manually define __dirname, enabling the app to serve static files correctly in production.