### PR TITLE
feat: changed postioning and css of the Drawer Trigger

### DIFF
--- a/src/components/ThemeDrawer.jsx
+++ b/src/components/ThemeDrawer.jsx
@@ -2,16 +2,18 @@ import { useThemeContext } from '../context/ThemeContext';
 import { Drawer } from 'vaul';
 
 import SVGclose from "../assets/icons/close.svg?react";
-import SVGpicker from "../assets/icons/color-picker.svg?react";
+//import SVGpicker from "../assets/icons/color-picker.svg?react";
 import './ThemeDrawer.css';
 
-export function ThemeDrawer() {
+export function ThemeDrawer({children}) {
   const { color, setColor } = useThemeContext();
   const colors = ["red", "orange", "yellow", "green", "cyan", "blue", "indigo", "purple"];
 
   return (
     <Drawer.Root>
-      <Drawer.Trigger className="vaul-drawer-trigger"><SVGpicker /></Drawer.Trigger>
+      <Drawer.Trigger className="vaul-drawer-trigger">
+        {children}
+      </Drawer.Trigger>
       <Drawer.Portal>
         <Drawer.Overlay className="vaul-drawer-overlay" />
         <Drawer.Content className="vaul-drawer-content">

--- a/src/pages/Landing.css
+++ b/src/pages/Landing.css
@@ -45,38 +45,6 @@
   left: 0;
   width: 100%;
   padding: var(--space-lg);
-
-  & .theme-settings {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-sm);
-    border-radius: var(--border-radius-md);
-    /*transition: background-color 0.3s ease-in-out;*/
-
-    & .color-picker {
-      display: none;
-      transition: opacity 0.3s ease-in-out;
-      opacity: 0;
-    }
-
-    /*&:hover {
-      background-color: var(--background-primary);
-    }*/
-
-    &:hover .color-picker {
-      display: block;
-      opacity: 1;
-    }
-  }
-}
-
-@media (hover: none) {
-  .landing-page footer .theme-settings .color-picker {
-    display: block;
-    opacity: 1;
-  }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/Landing.css
+++ b/src/pages/Landing.css
@@ -48,13 +48,34 @@
 
   & .theme-settings {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
     gap: var(--space-sm);
-    min-width: 768px;
-    max-width: 1000px;
-    margin: 0 auto;
+    border-radius: var(--border-radius-md);
+    /*transition: background-color 0.3s ease-in-out;*/
+
+    & .color-picker {
+      display: none;
+      transition: opacity 0.3s ease-in-out;
+      opacity: 0;
+    }
+
+    /*&:hover {
+      background-color: var(--background-primary);
+    }*/
+
+    &:hover .color-picker {
+      display: block;
+      opacity: 1;
+    }
+  }
+}
+
+@media (hover: none) {
+  .landing-page footer .theme-settings .color-picker {
+    display: block;
+    opacity: 1;
   }
 }
 

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -23,18 +23,16 @@ export function Landing({ errorMessage }) {
       <header>
         <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
         <p>Do you need an umbrella today?</p>
-        <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+        <ThemeDrawer >
+          <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+        </ThemeDrawer>
       </header>
       <main>
         <LocationGeo />
         <LocationSearchLink type="text" />
       </main>
       <footer>
-        <div className="theme-settings">
-          <ThemeDrawer />
-          <ThemeToggle />
-          {/*<ThemeDrawer />*/}
-        </div>
+        <ThemeToggle />
       </footer>
     </div>
   );

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -31,8 +31,9 @@ export function Landing({ errorMessage }) {
       </main>
       <footer>
         <div className="theme-settings">
-          <ThemeToggle />
           <ThemeDrawer />
+          <ThemeToggle />
+          {/*<ThemeDrawer />*/}
         </div>
       </footer>
     </div>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 
 import { LocationSearchLink } from '../components/LocationSearch';
 import LocationGeo from '../components/LocationGeo';
+import { ThemeToggle } from '../components/ThemeToggle';
+import { ThemeDrawer } from '../components/ThemeDrawer';
 
 import SVGlogo from '../assets/logo/brolly.svg?react';
 import dogs from '../assets/images/brolly-dogs.png';
@@ -52,7 +54,9 @@ export function NotFound() {
     <div className="notfound-page">
       <header>
         <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
-        <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+        <ThemeDrawer >
+          <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+        </ThemeDrawer>
         <div className="location-links">
           <LocationSearchLink type="icon" />
           <LocationGeo type="icon" />
@@ -69,6 +73,9 @@ export function NotFound() {
         <p>Lola and Lily are keeping dry - you should too!</p>
       </main>
 
+      <footer>
+        <ThemeToggle />
+      </footer>
       <div className="rain front-row" ref={rainFrontRef}></div>
       <div className="rain back-row" ref={rainBackRef}></div>
     </div>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 
 import { LocationSearchLink } from '../components/LocationSearch';
 import LocationGeo from '../components/LocationGeo';
-import { ThemeToggle } from '../components/ThemeToggle';
 
 import SVGlogo from '../assets/logo/brolly.svg?react';
 import dogs from '../assets/images/brolly-dogs.png';
@@ -70,9 +69,6 @@ export function NotFound() {
         <p>Lola and Lily are keeping dry - you should too!</p>
       </main>
 
-      <footer>
-        <ThemeToggle />
-      </footer>
       <div className="rain front-row" ref={rainFrontRef}></div>
       <div className="rain back-row" ref={rainBackRef}></div>
     </div>

--- a/src/pages/Weather.css
+++ b/src/pages/Weather.css
@@ -151,39 +151,6 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-
-  & .theme-settings {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-sm);
-    /*padding-right: var(--space-sm);*/
-    border-radius: var(--border-radius-md);
-    /*transition: background-color 0.3s ease-in-out;*/
-
-    & .color-picker {
-      display: none;
-      transition: opacity 0.3s ease-in-out;
-      opacity: 0;
-    }
-
-    /*&:hover {
-      background-color: var(--background-primary);
-    }*/
-
-    &:hover .color-picker {
-      display: block;
-      opacity: 1;
-    }
-  }
-}
-
-@media (hover: none) {
-  .weather-page footer .theme-settings .color-picker {
-    display: block;
-    opacity: 1;
-  }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/Weather.css
+++ b/src/pages/Weather.css
@@ -158,9 +158,31 @@
     align-items: center;
     justify-content: center;
     gap: var(--space-sm);
-    background-color: var(--background-primary);
-    padding-right: var(--space-sm);
+    /*padding-right: var(--space-sm);*/
     border-radius: var(--border-radius-md);
+    /*transition: background-color 0.3s ease-in-out;*/
+
+    & .color-picker {
+      display: none;
+      transition: opacity 0.3s ease-in-out;
+      opacity: 0;
+    }
+
+    /*&:hover {
+      background-color: var(--background-primary);
+    }*/
+
+    &:hover .color-picker {
+      display: block;
+      opacity: 1;
+    }
+  }
+}
+
+@media (hover: none) {
+  .weather-page footer .theme-settings .color-picker {
+    display: block;
+    opacity: 1;
   }
 }
 

--- a/src/pages/Weather.jsx
+++ b/src/pages/Weather.jsx
@@ -48,7 +48,9 @@ export function Weather() {
         <div className="weather-page">
           <header>
             <h1>Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance</h1>
-            <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+            <ThemeDrawer >
+              <SVGlogo role="img" alt="Brolly: Get Your Local UK Weather Forecast and Umbrella Guidance" />
+            </ThemeDrawer>
             <div className="location-links">
               <LocationSearchLink type="icon" />
               <LocationGeo type="icon" />
@@ -67,10 +69,7 @@ export function Weather() {
           </main>
 
           <footer>
-            <div className="theme-settings">
-              <ThemeToggle />
-              <ThemeDrawer />
-            </div>
+            <ThemeToggle />
             <UnitToggle />
           </footer>
         </div>


### PR DESCRIPTION
Users can reveal and hide the trigger for the color selection Vaul Drawer by hovering over `theme-settings`. A fallback ensures accessibility on devices where hover isn't available.